### PR TITLE
Fix dependency on setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "feat-feedback-tool"
-version = "0.4.0"
+version = "0.4.1"
 description = "Create fast feedback based on prewritten sentences combined with personalised messages."
 readme = "README.md"
 authors = ["AnneliesVlaar <66774020+AnneliesVlaar@users.noreply.github.com>"]

--- a/src/feat/views/gui.py
+++ b/src/feat/views/gui.py
@@ -1,8 +1,7 @@
 import sys
 import textwrap
-
-import pkg_resources
 from importlib import resources
+
 from PyQt6 import QtWidgets, uic
 from PyQt6.QtGui import QFont, QIcon, QMovie
 
@@ -25,7 +24,7 @@ class NewFileWindow(QtWidgets.QWidget):
 
         # load feat gui design
         uic.loadUi(
-            pkg_resources.resource_stream("feat.views", "gui_feat_new_file.ui"), self
+            resources.files("feat.views") / "gui_feat_new_file.ui", self
         )
 
         # set icon
@@ -102,7 +101,7 @@ class UserInterface(QtWidgets.QMainWindow):
         super().__init__()
 
         # load feat gui design
-        uic.loadUi(pkg_resources.resource_stream("feat.views", "gui_feat.ui"), self)
+        uic.loadUi(resources.files("feat.views") / "gui_feat.ui", self)
 
         # set icons
         self.setWindowIcon(


### PR DESCRIPTION
Unfortunately 0.4.0 still required setuptools, which was not specified as a dependency. Since Feat has almost completely switched over to importlib.resources, I completed that switch. It now works without setuptools.